### PR TITLE
Fix "pgmnt-commands" duplicate tag

### DIFF
--- a/doc/pgmnt.txt
+++ b/doc/pgmnt.txt
@@ -40,7 +40,7 @@ g:pgmnt_auto_source                                      *g:pgmnt_auto_source*
 
 
 ==============================================================================
-About                                                         *pgmnt-commands*
+About                                                         *pgmnt-about*
 
 |Pgmnt| is developed by cocopon and licensed under the MIT License.
 Visit the project page for the latest version:


### PR DESCRIPTION
Fix "pgmnt-commands" duplicate tag

helptags error:
```vim
Vim(helptags):E154: Duplicate tag "pgmnt-commands" in file /path/to/pgmnt.txt
```

Thanks for good talks in Vim Conf 2017 :)