### PR TITLE
Add color#hsv()

### DIFF
--- a/autoload/pgmnt/color.vim
+++ b/autoload/pgmnt/color.vim
@@ -115,6 +115,26 @@ function! pgmnt#color#hsl(h, s, l) abort
 endfunction
 
 
+function! pgmnt#color#hsv(h, s, v) abort
+  let h = s:constrain(a:h * 1.0, 0.0, 360.0)
+  let s = s:constrain(a:s * 1.0, 0.0, 1.0)
+  let v = s:constrain(a:v * 1.0, 0.0, 1.0)
+
+  let l = (2.0 - s) * v / 2.0
+  if l != 0.0
+    if l == 1.0
+      let s = 0.0
+    elseif l < 0.5
+      let s = a:s * a:v / (l * 2.0)
+    else
+      let s = a:s * a:v / (2.0 - l * 2.0)
+    endif
+  endif
+
+  return pgmnt#color#hsl(h, s, l)
+endfunction
+
+
 function! pgmnt#color#adjust_color(hex, options) abort
   let hsl_comps = s:rgb_comps_to_hsl_comps(
         \   s:hex_to_rgb_comps(a:hex)

--- a/test/pgmnt/color.vim
+++ b/test/pgmnt/color.vim
@@ -38,6 +38,34 @@ function! s:suite.test_hsl()
 endfunction
 
 
+function! s:suite.test_hsv()
+  call s:assert.equals(
+        \   pgmnt#color#hsv(0, 0, 0),
+        \   '#000000'
+        \ )
+  call s:assert.equals(
+        \   pgmnt#color#hsv(0, 0, 0.5),
+        \   '#7f7f7f'
+        \ )
+  call s:assert.equals(
+        \   pgmnt#color#hsv(0, 0, 1.0),
+        \   '#ffffff'
+        \ )
+  call s:assert.equals(
+        \   pgmnt#color#hsv(-10, -20, -30),
+        \   '#000000'
+        \ )
+  call s:assert.equals(
+        \   pgmnt#color#hsv(240, 1.0, 0.5),
+        \   '#00007f'
+        \ )
+  call s:assert.equals(
+        \   pgmnt#color#hsv(160, 0.25, 0.75),
+        \   '#8fbfaf'
+        \ )
+endfunction
+
+
 function! s:suite.test_darken()
   call s:assert.equals(
         \   pgmnt#color#darken('#daf5a3', 0.2),


### PR DESCRIPTION
This PR proposes adding a `pgmnt#color#hsv()` function for computing colors.

There are cases where theme color definitions using HSV may make better sense. Under the hood, the `hsv()` function translates itself as a call to `hsl()`.

Thanks!